### PR TITLE
make bindings for renamed functions const

### DIFF
--- a/src/Case.jl
+++ b/src/Case.jl
@@ -23,12 +23,12 @@ module Case
   #  core load
   # ===========
 
-  upcase = uppercase
-  downcase = lowercase
+  const upcase = uppercase
+  const downcase = lowercase
 
   include("public/index.jl")
   include("private/index.jl")
 
-  decamelize = _decamelize
+  const decamelize = _decamelize
 
 end


### PR DESCRIPTION
Slow and type unstable otherwise.

Before:

```jl
julia> @code_warntype spacecase(cur_string)
Variables:
  #self# <optimized out>
  cur_string::String

Body:
  begin
      return $(Expr(:invoke, MethodInstance for _defaultcase(::String), :(Case._defaultcase), :(cur_string)))
  end::Any
```

After:

```jl
julia> @code_warntype spacecase(cur_string)
Variables:
  #self# <optimized out>
  cur_string::String

Body:
  begin
      return $(Expr(:invoke, MethodInstance for _defaultcase(::String), :(Case._defaultcase), :(cur_string)))
  end::String
```