### PR TITLE
Start upgrading StringCases for Julia >= 1.0 

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,2 @@
+# This file is machine-generated - editing it directly is not advised
+

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,4 @@
+name = "StringCases"
+uuid = "f22f4433-750e-5048-95f9-cae576f2c120"
+authors = ["Dan Segal <dan@seg.al>", "Vincent Laugier <vincent.laugier@gmail.com>"]
+version = "0.1.0"

--- a/src/StringCases.jl
+++ b/src/StringCases.jl
@@ -1,4 +1,4 @@
-__precompile__()
+# __precompile__()
 
 module StringCases
 

--- a/src/private/_delimcase.jl
+++ b/src/private/_delimcase.jl
@@ -1,7 +1,6 @@
 function _delimcase(cur_string::AbstractString, cur_delim::AbstractString)
   replace(
     _defaultcase(cur_string),
-    " ",
-    cur_delim
+    " " => cur_delim
   )
 end

--- a/src/private/_purgecase.jl
+++ b/src/private/_purgecase.jl
@@ -1,6 +1,6 @@
 function _purgecase(cur_string::AbstractString)
-  cur_string = replace(cur_string, "-", " ")
-  cur_string = replace(cur_string, "_", " ")
+  cur_string = replace(cur_string, "-" => " ")
+  cur_string = replace(cur_string, "_" => " ")
 
   cur_string
 end

--- a/src/public/camelcase.jl
+++ b/src/public/camelcase.jl
@@ -1,3 +1,3 @@
 function camelcase(cur_string::AbstractString)
-  lcfirst(pascalcase(cur_string))
+  lowercasefirst(pascalcase(cur_string))
 end

--- a/src/public/camelize.jl
+++ b/src/public/camelize.jl
@@ -1,7 +1,7 @@
 function camelize(cur_string::AbstractString)
   cur_string = classify(cur_string)
 
-  cur_string = join(map(x -> lcfirst(x), split(cur_string, "/")), "/")
+  cur_string = join(map(x -> lowercasefirst(x), split(cur_string, "/")), "/")
 
   cur_string
 end

--- a/src/public/capitalize.jl
+++ b/src/public/capitalize.jl
@@ -1,5 +1,5 @@
 function capitalize(cur_string::AbstractString)
-  cur_string = join(map(x -> ucfirst(x), split(cur_string, "/")), "/")
+  cur_string = join(map(x -> uppercasefirst(x), split(cur_string, "/")), "/")
 
   cur_string
 end

--- a/src/public/classify.jl
+++ b/src/public/classify.jl
@@ -1,7 +1,7 @@
 function classify(cur_string::AbstractString)
   cur_string = capitalize(cur_string)
 
-  cur_string = join(map(x -> ucfirst(x), split(cur_string, r"[- _]")))
+  cur_string = join(map(x -> uppercasefirst(x), split(cur_string, r"[- _]")))
 
   cur_string
 end

--- a/src/public/pascalcase.jl
+++ b/src/public/pascalcase.jl
@@ -1,7 +1,6 @@
 function pascalcase(cur_string::AbstractString)
   replace(
     titlecase(_defaultcase(cur_string)),
-    " ",
-    ""
+    " " => ""
   )
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,15 +1,24 @@
-using Base.Test
+using Pkg
+Pkg.activate(".")
+
+using Revise
+
+using Test
 
 using StringCases
 
 import StringCases._defaultcase
 import StringCases._decamelize
 
+
+
 # -------------------
 #  test plain string
 # -------------------
 
 test_string = "foo BAR bAZ"
+
+StringCases.camelize("dwed_dewew")
 
 @test _defaultcase(test_string) == "foo bar baz"
 


### PR DESCRIPTION
The following functions are now working: camelize, _defaultcase, spacecase, pascalcase, camelcase, snakecase, kebabcase

The following functions are still not working because we need to replace the blocks using 'matchall': 
underscore, dasherize, _decamelize
