### PR TITLE
Fix matchall

### DIFF
--- a/src/private/_decamelize.jl
+++ b/src/private/_decamelize.jl
@@ -1,5 +1,5 @@
 function _decamelize(cur_string::AbstractString)
-  capital_letters = matchall(r"[A-Z]+", cur_string)
+  capital_letters = collect(m.match for m in eachmatch(r"[A-Z]+", cur_string))
   capital_letters = map(x -> downcase(x), capital_letters)
 
   lowercase_phrases = split(cur_string, r"([A-Z]+)")


### PR DESCRIPTION
From [Julia v1.5 release notes](https://github.com/JuliaLang/julia/blob/70a5901d5f29c9bc97cd22f800434f209efe5241/HISTORY.md#deprecated-or-removed-4),

> matchall has been deprecated in favor of collect(m.match for m in eachmatch(r, s)) (#26071).

